### PR TITLE
add ghw2018_snowmelt_data folder to git for consistent data storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tif
 *.mat
+.DS_Store


### PR DESCRIPTION
added an empty file `.keep` into the ghw2018_snowmelt_data folder to allow us to commit that folder into the repository so that we all use consistent naming for our data folder